### PR TITLE
Fix to work with Shaarli when server adds X-Frame-Options DENY header

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1,0 +1,17 @@
+chrome.webRequest.onHeadersReceived.addListener(
+    function(info) {
+        var headers = info.responseHeaders;
+        for (var i=headers.length-1; i>=0; --i) {
+            var header = headers[i].name.toLowerCase();
+            if (header == 'x-frame-options' || header == 'frame-options') {
+                headers.splice(i, 1); // Remove header
+            }
+        }
+        return {responseHeaders: headers};
+    },
+    {
+        urls: [ '<all_urls>' ], // Pattern to match all http(s) pages
+        types: [ 'sub_frame' ]
+    },
+    ['blocking', 'responseHeaders']
+);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -13,8 +13,11 @@
   },
   "options_page" : "fancy-settings/index.html",
   "permissions": [
-    "https://www.googleapis.com/",
+    "webRequest",
+    "webRequestBlocking",
+    "*://*/*",
     "tabs"
   ],
-  "offline_enabled": false
+  "offline_enabled": false,
+  "background": {"scripts":["js/background.js"]}
 }


### PR DESCRIPTION
Added background.js & amended manifest to use webRequest API to remove
X-Frame-Options headers from requested URLs in order to allow use of
Shaarli instances on servers that add X-Frame-Options DENY headers.
