### PR TITLE
Add option to skip description field

### DIFF
--- a/src/fancy-settings/manifest.js
+++ b/src/fancy-settings/manifest.js
@@ -1,27 +1,30 @@
 // SAMPLE
 this.manifest = {
-    "name": "Shiny Shaarly",
-    "icon": "../assets/48x48.png",
-    "settings": [
-        {
-            "tab": i18n.get("Shaarli configuration"),
-            "group": i18n.get("Server information"),
-            "name": "base_url",
-            "type": "text",
-            "label": i18n.get("Base URL"),
-            "text": i18n.get("x-url")
-        },
-        {
-            "tab": i18n.get("Shaarli configuration"),
-            "group": i18n.get("Server information"),
-            "name": "myDescription",
-            "type": "description",
-            "text": i18n.get("description")
-        },
-    ],
-    "alignment": [
-        [
-            "base_url"
-        ]
-    ]
+  name: 'Shiny Shaarly',
+  icon: '../assets/48x48.png',
+  settings: [
+    {
+      tab: i18n.get('Shaarli configuration'),
+      group: i18n.get('Server information'),
+      name: 'base_url',
+      type: 'text',
+      label: i18n.get('Base URL'),
+      text: i18n.get('x-url'),
+    },
+    {
+      tab: i18n.get('Shaarli configuration'),
+      group: i18n.get('Server information'),
+      name: 'myDescription',
+      type: 'description',
+      text: i18n.get('description'),
+    },
+    {
+      tab: i18n.get('Shaarli configuration'),
+      group: i18n.get('Preferences'),
+      name: 'skip_description',
+      type: 'checkbox',
+      label: i18n.get('Skip description and start on tags'),
+    },
+  ],
+  alignment: [['base_url']],
 };

--- a/src/fancy-settings/manifest.js
+++ b/src/fancy-settings/manifest.js
@@ -1,30 +1,34 @@
 // SAMPLE
 this.manifest = {
-  name: 'Shiny Shaarly',
-  icon: '../assets/48x48.png',
-  settings: [
-    {
-      tab: i18n.get('Shaarli configuration'),
-      group: i18n.get('Server information'),
-      name: 'base_url',
-      type: 'text',
-      label: i18n.get('Base URL'),
-      text: i18n.get('x-url'),
-    },
-    {
-      tab: i18n.get('Shaarli configuration'),
-      group: i18n.get('Server information'),
-      name: 'myDescription',
-      type: 'description',
-      text: i18n.get('description'),
-    },
-    {
-      tab: i18n.get('Shaarli configuration'),
-      group: i18n.get('Preferences'),
-      name: 'skip_description',
-      type: 'checkbox',
-      label: i18n.get('Skip description and start on tags'),
-    },
-  ],
-  alignment: [['base_url']],
+    "name": "Shiny Shaarly",
+    "icon": "../assets/48x48.png",
+    "settings": [
+        {
+            "tab": i18n.get("Shaarli configuration"),
+            "group": i18n.get("Server information"),
+            "name": "base_url",
+            "type": "text",
+            "label": i18n.get("Base URL"),
+            "text": i18n.get("x-url")
+        },
+        {
+            "tab": i18n.get("Shaarli configuration"),
+            "group": i18n.get("Server information"),
+            "name": "myDescription",
+            "type": "description",
+            "text": i18n.get("description")
+        },
+        {
+            "tab": i18n.get("Shaarli configuration"),
+            "group": i18n.get("Preferences"),
+            "name": "skip_description",
+            "type": "checkbox",
+            "label": i18n.get("Skip description and start on tags")
+        }
+    ],
+    "alignment": [
+        [
+            "base_url"
+        ]
+    ]
 };

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1,30 +1,22 @@
-function populate_iframe() {
+function populate_iframe()
+{
   chrome.tabs.getSelected(null, function(tab) {
-    var settings = new Store('settings', {});
+    var settings = new Store("settings", {});
     var options = settings.toObject();
     var base_url, skip_description;
     console.log(options);
     base_url = options['base_url'];
     skip_description = options['skip_description'];
-    if (base_url == null) {
-      document
-        .getElementById('configure_me')
-        .setAttribute('style', 'display:block');
-      document.getElementById('source').setAttribute('style', 'display:none');
+    if(base_url == null)
+    {
+      document.getElementById('configure_me').setAttribute('style','display:block');
+      document.getElementById('source').setAttribute('style','display:none');
     } else {
-      document
-        .getElementById('configure_me')
-        .setAttribute('style', 'display:none');
-      document.getElementById('source').setAttribute('style', 'display:block');
+      document.getElementById('configure_me').setAttribute('style','display:none');
+      document.getElementById('source').setAttribute('style','display:block');
       var url = tab.url;
       var title = tab.title || url;
-      var if_url =
-        base_url +
-        '/?post=' +
-        encodeURIComponent(url) +
-        '&title=' +
-        encodeURIComponent(title) +
-        '&source=shiny_shaarli';
+      var if_url = base_url + '/?post=' + encodeURIComponent(url)+'&title=' + encodeURIComponent(title)+'&source=shiny_shaarli';
       if (skip_description) {
         if_url += '&description=%20';
       }
@@ -35,4 +27,4 @@ function populate_iframe() {
 
 window.onload = function() {
   populate_iframe();
-};
+}

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1,21 +1,33 @@
-function populate_iframe()
-{
+function populate_iframe() {
   chrome.tabs.getSelected(null, function(tab) {
-    var settings = new Store("settings", {});
+    var settings = new Store('settings', {});
     var options = settings.toObject();
-    var base_url;
+    var base_url, skip_description;
     console.log(options);
     base_url = options['base_url'];
-    if(base_url == null)
-    {
-      document.getElementById('configure_me').setAttribute('style','display:block');
-      document.getElementById('source').setAttribute('style','display:none');
+    skip_description = options['skip_description'];
+    if (base_url == null) {
+      document
+        .getElementById('configure_me')
+        .setAttribute('style', 'display:block');
+      document.getElementById('source').setAttribute('style', 'display:none');
     } else {
-      document.getElementById('configure_me').setAttribute('style','display:none');
-      document.getElementById('source').setAttribute('style','display:block');
+      document
+        .getElementById('configure_me')
+        .setAttribute('style', 'display:none');
+      document.getElementById('source').setAttribute('style', 'display:block');
       var url = tab.url;
       var title = tab.title || url;
-      var if_url = base_url + '/?post=' + encodeURIComponent(url)+'&title=' + encodeURIComponent(title)+'&source=shiny_shaarli';
+      var if_url =
+        base_url +
+        '/?post=' +
+        encodeURIComponent(url) +
+        '&title=' +
+        encodeURIComponent(title) +
+        '&source=shiny_shaarli';
+      if (skip_description) {
+        if_url += '&description=%20';
+      }
       document.getElementById('source').setAttribute('src', if_url);
     }
   });
@@ -23,4 +35,4 @@ function populate_iframe()
 
 window.onload = function() {
   populate_iframe();
-}
+};

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,18 +3,21 @@
   "version": "1.0.8",
   "manifest_version": 2,
   "description": "Open Shaarli post interface from inside Chrome.",
-  "icons": {
-    "16": "assets/16x16.png",
-    "48": "assets/48x48.png",
-    "128": "assets/128x128.png"
-  },
+  "icons": { "16": "assets/16x16.png",
+         "48": "assets/48x48.png",
+        "128": "assets/128x128.png" },
   "browser_action": {
     "default_icon": "assets/button_icon.png",
-    "default_title": "Open Shaarli",
+    "default_title" : "Open Shaarli",
     "default_popup": "html/popup.html"
   },
-  "options_page": "fancy-settings/index.html",
-  "permissions": ["webRequest", "webRequestBlocking", "*://*/*", "tabs"],
+  "options_page" : "fancy-settings/index.html",
+  "permissions": [
+    "webRequest",
+    "webRequestBlocking",
+    "*://*/*",
+    "tabs"
+  ],
   "offline_enabled": false,
-  "background": {"scripts": ["js/background.js"]}
+  "background": {"scripts":["js/background.js"]}
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,23 +1,20 @@
 {
   "name": "Shiny Shaarli",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "manifest_version": 2,
   "description": "Open Shaarli post interface from inside Chrome.",
-  "icons": { "16": "assets/16x16.png",
-         "48": "assets/48x48.png",
-        "128": "assets/128x128.png" },
+  "icons": {
+    "16": "assets/16x16.png",
+    "48": "assets/48x48.png",
+    "128": "assets/128x128.png"
+  },
   "browser_action": {
     "default_icon": "assets/button_icon.png",
-    "default_title" : "Open Shaarli",
+    "default_title": "Open Shaarli",
     "default_popup": "html/popup.html"
   },
-  "options_page" : "fancy-settings/index.html",
-  "permissions": [
-    "webRequest",
-    "webRequestBlocking",
-    "*://*/*",
-    "tabs"
-  ],
+  "options_page": "fancy-settings/index.html",
+  "permissions": ["webRequest", "webRequestBlocking", "*://*/*", "tabs"],
   "offline_enabled": false,
-  "background": {"scripts":["js/background.js"]}
+  "background": {"scripts": ["js/background.js"]}
 }


### PR DESCRIPTION
I normally do not enter a description when saving a link, but I do always add tags. This change allows for the option to put the focus directly on the tags section to facilitate that workflow. It adds a toggle for this setting in the Options Page