### PR TITLE
Fix "Wrong Token" error

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,6 +15,7 @@
   "permissions": [
     "webRequest",
     "webRequestBlocking",
+    "*://*/*",
     "activeTab"
   ],
   "offline_enabled": false,


### PR DESCRIPTION
Fix #7, https://github.com/shaarli/Shaarli/issues/1594.

Due to `Unchecked runtime.lastError: You need to request host permissions in the manifest file in order to be notified about requests from the webRequest API.`